### PR TITLE
fix: Skip mininum-gas-prices validation because we don't have any gas fees

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -277,11 +277,8 @@ func GetConfig(v *viper.Viper) (Config, error) {
 	return *conf, nil
 }
 
-// ValidateBasic returns an error if min-gas-prices field is empty in BaseConfig. Otherwise, it returns nil.
+// ValidateBasic returns an error if the Config is invalid.
 func (c Config) ValidateBasic() error {
-	if c.BaseConfig.MinGasPrices == "" {
-		return sdkerrors.ErrAppConfig.Wrap("set min gas price in app.toml or flag or env variable")
-	}
 	if c.Pruning == pruningtypes.PruningOptionEverything && c.StateSync.SnapshotInterval > 0 {
 		return sdkerrors.ErrAppConfig.Wrapf(
 			"cannot enable state sync snapshots with '%s' pruning setting", pruningtypes.PruningOptionEverything,


### PR DESCRIPTION
# Description

Skip mininum-gas-prices validation because we don't have any gas fees