### PR TITLE
Set VoteExtensionsEnableHeight to 1 by default

### DIFF
--- a/testutil/sims/app_helpers.go
+++ b/testutil/sims/app_helpers.go
@@ -50,8 +50,8 @@ var DefaultConsensusParams = &cmtproto.ConsensusParams{
 		},
 	},
 	Abci: &cmtproto.ABCIParams{
-		// returning a fixed non-nil value, set it to 100, and used for testing. In reality, it'll be the Heimdall v1 final height +1
-		VoteExtensionsEnableHeight: 100,
+		// returning a fixed non-nil value, set it to 1, and used for testing. In reality, it'll be the Heimdall v1 final height +1
+		VoteExtensionsEnableHeight: 1,
 	},
 }
 

--- a/x/genutil/utils.go
+++ b/x/genutil/utils.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
 
-const DefaultVEenabledHeight = 1
+const DefaultVEsEnabledHeight = 1
 
 // ExportGenesisFile creates and writes the genesis configuration to disk. An
 // error is returned if building or writing the configuration to file fails.
@@ -38,7 +38,7 @@ func ExportGenesisFileWithTime(genFile, chainID string, validators []cmttypes.Ge
 	appGenesis.GenesisTime = genTime
 	appGenesis.Consensus.Validators = validators
 	appGenesis.Consensus.Params = cmttypes.DefaultConsensusParams()
-	appGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = DefaultVEenabledHeight
+	appGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = DefaultVEsEnabledHeight
 
 	if err := appGenesis.ValidateAndComplete(); err != nil {
 		return err

--- a/x/genutil/utils.go
+++ b/x/genutil/utils.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
 
+const DefaultVEenabledHeight = 1
+
 // ExportGenesisFile creates and writes the genesis configuration to disk. An
 // error is returned if building or writing the configuration to file fails.
 func ExportGenesisFile(genesis *types.AppGenesis, genFile string) error {
@@ -35,6 +37,7 @@ func ExportGenesisFileWithTime(genFile, chainID string, validators []cmttypes.Ge
 	appGenesis := types.NewAppGenesisWithVersion(chainID, appState)
 	appGenesis.GenesisTime = genTime
 	appGenesis.Consensus.Validators = validators
+	appGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = DefaultVEenabledHeight
 
 	if err := appGenesis.ValidateAndComplete(); err != nil {
 		return err

--- a/x/genutil/utils.go
+++ b/x/genutil/utils.go
@@ -37,6 +37,7 @@ func ExportGenesisFileWithTime(genFile, chainID string, validators []cmttypes.Ge
 	appGenesis := types.NewAppGenesisWithVersion(chainID, appState)
 	appGenesis.GenesisTime = genTime
 	appGenesis.Consensus.Validators = validators
+	appGenesis.Consensus.Params = cmttypes.DefaultConsensusParams()
 	appGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = DefaultVEenabledHeight
 
 	if err := appGenesis.ValidateAndComplete(); err != nil {


### PR DESCRIPTION
# Description

This PR sets `VoteExtensionsEnableHeight` to 1 by default, which is the config we will be using for testing in devnets. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

