### PR TITLE
default configs for logs and server address

### DIFF
--- a/contrib/images/simd-dlv/Dockerfile
+++ b/contrib/images/simd-dlv/Dockerfile
@@ -24,7 +24,7 @@ FROM alpine AS run
 RUN apk add bash curl jq
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
-CMD ["start", "--log_format", "plain"]
+CMD ["start", "--log_format", "json"]
 STOPSIGNAL SIGTERM
 VOLUME /simd
 WORKDIR /simd

--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine AS run
 RUN apk add bash curl jq
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
-CMD ["start", "--log_format", "plain"]
+CMD ["start", "--log_format", "json"]
 STOPSIGNAL SIGTERM
 VOLUME /simd
 WORKDIR /simd

--- a/server/cmd/execute.go
+++ b/server/cmd/execute.go
@@ -27,7 +27,7 @@ func Execute(rootCmd *cobra.Command, envPrefix, defaultHome string) error {
 
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>')")
 	// NOTE: The default logger is only checking for the "json" value, any other value will default to plain text.
-	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "plain", "The logging format (json|plain)")
+	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "json", "The logging format (json|plain)")
 	rootCmd.PersistentFlags().Bool(flags.FlagLogNoColor, false, "Disable colored logs")
 
 	executor := cmtcli.PrepareBaseCmd(rootCmd, envPrefix, defaultHome)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -17,7 +17,7 @@ const (
 	defaultMinGasPrices = ""
 
 	// DefaultAPIAddress defines the default address to bind the API server to.
-	DefaultAPIAddress = "tcp://localhost:1317"
+	DefaultAPIAddress = "tcp://0.0.0.0:1317"
 
 	// DefaultGRPCAddress defines the default address to bind the gRPC server to.
 	DefaultGRPCAddress = "localhost:9090"
@@ -237,7 +237,7 @@ func DefaultConfig() *Config {
 		},
 		API: APIConfig{
 			Enable:             false,
-			Swagger:            false,
+			Swagger:            true,
 			Address:            DefaultAPIAddress,
 			MaxOpenConnections: 1000,
 			RPCReadTimeout:     10,


### PR DESCRIPTION
# Description

Default configs for json log output format and rest server to be 0.0.0.0
