### PR TITLE
plain logs for cosmos

### DIFF
--- a/contrib/images/simd-dlv/Dockerfile
+++ b/contrib/images/simd-dlv/Dockerfile
@@ -24,7 +24,7 @@ FROM alpine AS run
 RUN apk add bash curl jq
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
-CMD ["start", "--log_format", "json"]
+CMD ["start", "--log_format", "plain"]
 STOPSIGNAL SIGTERM
 VOLUME /simd
 WORKDIR /simd

--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine AS run
 RUN apk add bash curl jq
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
-CMD ["start", "--log_format", "json"]
+CMD ["start", "--log_format", "plain"]
 STOPSIGNAL SIGTERM
 VOLUME /simd
 WORKDIR /simd

--- a/server/cmd/execute.go
+++ b/server/cmd/execute.go
@@ -27,7 +27,7 @@ func Execute(rootCmd *cobra.Command, envPrefix, defaultHome string) error {
 
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>')")
 	// NOTE: The default logger is only checking for the "json" value, any other value will default to plain text.
-	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "json", "The logging format (json|plain)")
+	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "plain", "The logging format (json|plain)")
 	rootCmd.PersistentFlags().Bool(flags.FlagLogNoColor, false, "Disable colored logs")
 
 	executor := cmtcli.PrepareBaseCmd(rootCmd, envPrefix, defaultHome)


### PR DESCRIPTION
# Description

Use plain logs for cosmos. In heimdall, this is still the best choice as it aligns with non-cosmos modules, cometBFT and rabbimq standars.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
