### PR TITLE
init command populates Genesis Validators

### DIFF
--- a/x/genutil/client/cli/helper.go
+++ b/x/genutil/client/cli/helper.go
@@ -2,16 +2,12 @@ package cli
 
 import (
 	"encoding/json"
-  "errors"
 
 	stakeType "github.com/0xPolygon/heimdall-v2/x/stake/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
 func SetGenesisValidator(valPubKey cryptotypes.PubKey) (json.RawMessage, error) {
-  if valPubKey == nil {
-		return nil, errors.New("invalid public key: nil")
-	}
 	genesisState := stakeType.GenesisState{
 		CurrentValidatorSet: stakeType.ValidatorSet{
 			Validators: []*stakeType.Validator{

--- a/x/genutil/client/cli/helper.go
+++ b/x/genutil/client/cli/helper.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"encoding/json"
+	stakeType "github.com/0xPolygon/heimdall-v2/x/stake/types"
+  cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+
+)
+
+func SetGenesisValidator(valPubKey cryptotypes.PubKey) (json.RawMessage, error) {
+	genesisState := stakeType.GenesisState{
+		CurrentValidatorSet: stakeType.ValidatorSet{
+			Validators: []*stakeType.Validator{
+				{
+					EndEpoch:         0,
+					ValId:            1,
+					StartEpoch:       0,
+					Nonce:            0,
+					VotingPower:      1000,
+					PubKey:           valPubKey.Bytes(),
+					Signer:           "0x" + valPubKey.Address().String(),
+					LastUpdated:      "",
+					Jailed:           false,
+					ProposerPriority: 0,
+				},
+			},
+		},
+		Validators: []*stakeType.Validator{
+			{
+				ValId:            1,
+				StartEpoch:       0,
+				EndEpoch:         1000000,
+				Nonce:            0,
+				VotingPower:      1000,
+				PubKey:           valPubKey.Bytes(),
+				Signer:           "0x" + valPubKey.Address().String(),
+				LastUpdated:      "",
+				Jailed:           false,
+				ProposerPriority: 0,
+			},
+		},
+	}
+
+	data, err := json.Marshal(genesisState)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.RawMessage(data), nil
+}
+

--- a/x/genutil/client/cli/helper.go
+++ b/x/genutil/client/cli/helper.go
@@ -2,12 +2,16 @@ package cli
 
 import (
 	"encoding/json"
+  "errors"
 
 	stakeType "github.com/0xPolygon/heimdall-v2/x/stake/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
 func SetGenesisValidator(valPubKey cryptotypes.PubKey) (json.RawMessage, error) {
+  if valPubKey == nil {
+		return nil, errors.New("invalid public key: nil")
+	}
 	genesisState := stakeType.GenesisState{
 		CurrentValidatorSet: stakeType.ValidatorSet{
 			Validators: []*stakeType.Validator{

--- a/x/genutil/client/cli/helper.go
+++ b/x/genutil/client/cli/helper.go
@@ -2,9 +2,9 @@ package cli
 
 import (
 	"encoding/json"
-	stakeType "github.com/0xPolygon/heimdall-v2/x/stake/types"
-  cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 
+	stakeType "github.com/0xPolygon/heimdall-v2/x/stake/types"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
 func SetGenesisValidator(valPubKey cryptotypes.PubKey) (json.RawMessage, error) {
@@ -48,4 +48,3 @@ func SetGenesisValidator(valPubKey cryptotypes.PubKey) (json.RawMessage, error) 
 
 	return json.RawMessage(data), nil
 }
-

--- a/x/genutil/client/cli/helper_test.go
+++ b/x/genutil/client/cli/helper_test.go
@@ -137,3 +137,12 @@ func TestSetGenesisValidatorJSON(t *testing.T) {
 	require.True(t, ok, "signer should be a string")
 	require.Equal(t, expectedSigner, signer)
 }
+
+// TestSetGenesisValidator_ErrorHandling tests error handling in SetGenesisValidator
+func TestSetGenesisValidator_ErrorHandling(t *testing.T) {
+	// Passing a nil public key to check if error handling works
+	rawMsg, err := cli.SetGenesisValidator(nil)
+	require.Error(t, err)
+	require.Nil(t, rawMsg)
+	require.Equal(t, "invalid public key: nil", err.Error()) // Validate the error message
+}

--- a/x/genutil/client/cli/helper_test.go
+++ b/x/genutil/client/cli/helper_test.go
@@ -2,78 +2,88 @@ package cli_test
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 
 	stakeType "github.com/0xPolygon/heimdall-v2/x/stake/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	"github.com/stretchr/testify/require"
-  "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
-
 )
 
-func TestSetGenesisValidator(t *testing.T) {
+// Helper function to get and sort keys from a map
+func getKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
+func TestSetGenesisValidator(t *testing.T) {
+	// Generate a public key for testing
 	privKey := ed25519.GenPrivKey()
 	pubKey := privKey.PubKey()
 
+	// Call the function to test
 	rawMsg, err := cli.SetGenesisValidator(pubKey)
 	require.NoError(t, err)
 	require.NotNil(t, rawMsg)
 
+	// Verify the returned data is valid RawMessage
+	require.IsType(t, json.RawMessage{}, rawMsg)
+
+	// Unmarshal the JSON result
 	var genesisState stakeType.GenesisState
 	err = json.Unmarshal(rawMsg, &genesisState)
 	require.NoError(t, err)
 
+	// Validate the current validator set
 	require.Len(t, genesisState.CurrentValidatorSet.Validators, 1)
 	currentValidator := genesisState.CurrentValidatorSet.Validators[0]
-	
+
+	// Validate the validators list
 	require.Len(t, genesisState.Validators, 1)
 	validator := genesisState.Validators[0]
 
 	// Test current validator set fields
 	require.Equal(t, uint64(1), currentValidator.ValId)
-	require.Equal(t, uint64(0), currentValidator.StartEpoch)
-	require.Equal(t, uint64(0), currentValidator.EndEpoch)
-	require.Equal(t, uint64(0), currentValidator.Nonce)
 	require.Equal(t, int64(1000), currentValidator.VotingPower)
 	require.Equal(t, pubKey.Bytes(), currentValidator.PubKey)
 	require.Equal(t, "0x"+pubKey.Address().String(), currentValidator.Signer)
-	require.False(t, currentValidator.Jailed)
-	require.Equal(t, int64(0), currentValidator.ProposerPriority)
 
 	// Test validators list fields
 	require.Equal(t, uint64(1), validator.ValId)
 	require.Equal(t, uint64(0), validator.StartEpoch)
 	require.Equal(t, uint64(1000000), validator.EndEpoch)
-	require.Equal(t, uint64(0), validator.Nonce)
 	require.Equal(t, int64(1000), validator.VotingPower)
 	require.Equal(t, pubKey.Bytes(), validator.PubKey)
 	require.Equal(t, "0x"+pubKey.Address().String(), validator.Signer)
-	require.False(t, validator.Jailed)
-	require.Equal(t, int64(0), validator.ProposerPriority)
-
-	// Test error case with invalid marshaling (this would require mocking json.Marshal)
-	// This is an advanced test that would require dependency injection or mocking
 }
 
 // TestSetGenesisValidatorJSON tests the JSON structure of the output
 func TestSetGenesisValidatorJSON(t *testing.T) {
-
+	// Generate a public key with known output for testing
 	privKey := ed25519.GenPrivKey()
 	pubKey := privKey.PubKey()
-	
+
+	// Get the expected address string
 	expectedSigner := "0x" + pubKey.Address().String()
 
+	// Call the function to test
 	rawMsg, err := cli.SetGenesisValidator(pubKey)
 	require.NoError(t, err)
 
+	// Convert to map to check JSON structure
 	var result map[string]interface{}
 	err = json.Unmarshal([]byte(rawMsg), &result)
 	require.NoError(t, err)
 
+	// Check top-level structure
 	currentValidatorSet, ok := result["current_validator_set"].(map[string]interface{})
 	require.True(t, ok, "current_validator_set should be a JSON object")
-	
+
 	validators, ok := result["validators"].([]interface{})
 	require.True(t, ok, "validators should be a JSON array")
 	require.Len(t, validators, 1)
@@ -83,22 +93,47 @@ func TestSetGenesisValidatorJSON(t *testing.T) {
 	require.True(t, ok, "current_validator_set.validators should be a JSON array")
 	require.Len(t, currentValidators, 1)
 
-	// Get and check the current validator
-	currentValidator := currentValidators[0].(map[string]interface{})
-	require.Equal(t, float64(1), currentValidator["val_id"])
-	require.Equal(t, float64(0), currentValidator["start_epoch"])
-	require.Equal(t, float64(0), currentValidator["end_epoch"])
-	require.Equal(t, float64(1000), currentValidator["voting_power"])
-	require.Equal(t, expectedSigner, currentValidator["signer"])
+	// Get the current validator
+	currentValidator, ok := currentValidators[0].(map[string]interface{})
+	require.True(t, ok)
+
+	// Check only the fields that exist in the JSON
+	valId, ok := currentValidator["val_id"].(float64)
+	require.True(t, ok, "val_id should be a number")
+	require.Equal(t, float64(1), valId)
+
+	votingPower, ok := currentValidator["voting_power"].(float64)
+	require.True(t, ok, "voting_power should be a number")
+	require.Equal(t, float64(1000), votingPower)
+
+	_, ok = currentValidator["pub_key"]
+	require.True(t, ok, "pub_key should exist")
+
+	signer, ok := currentValidator["signer"].(string)
+	require.True(t, ok, "signer should be a string")
+	require.Equal(t, expectedSigner, signer)
 
 	// Get and check the validator from validators array
-	validator := validators[0].(map[string]interface{})
-	require.Equal(t, float64(1), validator["val_id"])
-	require.Equal(t, float64(0), validator["start_epoch"])
-	require.Equal(t, float64(1000000), validator["end_epoch"])
-	require.Equal(t, float64(1000), validator["voting_power"])
-	require.Equal(t, expectedSigner, validator["signer"])
+	validator, ok := validators[0].(map[string]interface{})
+	require.True(t, ok, "validator should be a JSON object")
 
+	// Check fields that exist in this validator object
+	valId, ok = validator["val_id"].(float64)
+	require.True(t, ok, "val_id should be a number")
+	require.Equal(t, float64(1), valId)
+
+	endEpoch, ok := validator["end_epoch"].(float64)
+	require.True(t, ok, "end_epoch should be a number")
+	require.Equal(t, float64(1000000), endEpoch)
+
+	votingPower, ok = validator["voting_power"].(float64)
+	require.True(t, ok, "voting_power should be a number")
+	require.Equal(t, float64(1000), votingPower)
+
+	_, ok = validator["pub_key"]
+	require.True(t, ok, "pub_key should exist")
+
+	signer, ok = validator["signer"].(string)
+	require.True(t, ok, "signer should be a string")
+	require.Equal(t, expectedSigner, signer)
 }
-
-

--- a/x/genutil/client/cli/helper_test.go
+++ b/x/genutil/client/cli/helper_test.go
@@ -1,0 +1,104 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	stakeType "github.com/0xPolygon/heimdall-v2/x/stake/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/stretchr/testify/require"
+  "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+
+)
+
+func TestSetGenesisValidator(t *testing.T) {
+
+	privKey := ed25519.GenPrivKey()
+	pubKey := privKey.PubKey()
+
+	rawMsg, err := cli.SetGenesisValidator(pubKey)
+	require.NoError(t, err)
+	require.NotNil(t, rawMsg)
+
+	var genesisState stakeType.GenesisState
+	err = json.Unmarshal(rawMsg, &genesisState)
+	require.NoError(t, err)
+
+	require.Len(t, genesisState.CurrentValidatorSet.Validators, 1)
+	currentValidator := genesisState.CurrentValidatorSet.Validators[0]
+	
+	require.Len(t, genesisState.Validators, 1)
+	validator := genesisState.Validators[0]
+
+	// Test current validator set fields
+	require.Equal(t, uint64(1), currentValidator.ValId)
+	require.Equal(t, uint64(0), currentValidator.StartEpoch)
+	require.Equal(t, uint64(0), currentValidator.EndEpoch)
+	require.Equal(t, uint64(0), currentValidator.Nonce)
+	require.Equal(t, int64(1000), currentValidator.VotingPower)
+	require.Equal(t, pubKey.Bytes(), currentValidator.PubKey)
+	require.Equal(t, "0x"+pubKey.Address().String(), currentValidator.Signer)
+	require.False(t, currentValidator.Jailed)
+	require.Equal(t, int64(0), currentValidator.ProposerPriority)
+
+	// Test validators list fields
+	require.Equal(t, uint64(1), validator.ValId)
+	require.Equal(t, uint64(0), validator.StartEpoch)
+	require.Equal(t, uint64(1000000), validator.EndEpoch)
+	require.Equal(t, uint64(0), validator.Nonce)
+	require.Equal(t, int64(1000), validator.VotingPower)
+	require.Equal(t, pubKey.Bytes(), validator.PubKey)
+	require.Equal(t, "0x"+pubKey.Address().String(), validator.Signer)
+	require.False(t, validator.Jailed)
+	require.Equal(t, int64(0), validator.ProposerPriority)
+
+	// Test error case with invalid marshaling (this would require mocking json.Marshal)
+	// This is an advanced test that would require dependency injection or mocking
+}
+
+// TestSetGenesisValidatorJSON tests the JSON structure of the output
+func TestSetGenesisValidatorJSON(t *testing.T) {
+
+	privKey := ed25519.GenPrivKey()
+	pubKey := privKey.PubKey()
+	
+	expectedSigner := "0x" + pubKey.Address().String()
+
+	rawMsg, err := cli.SetGenesisValidator(pubKey)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal([]byte(rawMsg), &result)
+	require.NoError(t, err)
+
+	currentValidatorSet, ok := result["current_validator_set"].(map[string]interface{})
+	require.True(t, ok, "current_validator_set should be a JSON object")
+	
+	validators, ok := result["validators"].([]interface{})
+	require.True(t, ok, "validators should be a JSON array")
+	require.Len(t, validators, 1)
+
+	// Check current validator set structure
+	currentValidators, ok := currentValidatorSet["validators"].([]interface{})
+	require.True(t, ok, "current_validator_set.validators should be a JSON array")
+	require.Len(t, currentValidators, 1)
+
+	// Get and check the current validator
+	currentValidator := currentValidators[0].(map[string]interface{})
+	require.Equal(t, float64(1), currentValidator["val_id"])
+	require.Equal(t, float64(0), currentValidator["start_epoch"])
+	require.Equal(t, float64(0), currentValidator["end_epoch"])
+	require.Equal(t, float64(1000), currentValidator["voting_power"])
+	require.Equal(t, expectedSigner, currentValidator["signer"])
+
+	// Get and check the validator from validators array
+	validator := validators[0].(map[string]interface{})
+	require.Equal(t, float64(1), validator["val_id"])
+	require.Equal(t, float64(0), validator["start_epoch"])
+	require.Equal(t, float64(1000000), validator["end_epoch"])
+	require.Equal(t, float64(1000), validator["voting_power"])
+	require.Equal(t, expectedSigner, validator["signer"])
+
+}
+
+

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -136,6 +136,9 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			}
 			appGenState := mbm.DefaultGenesis(cdc)
 			appGenState["stake"], err = SetGenesisValidator(valPublicKey)
+      if err != nil {
+        return fmt.Errorf("Failed to add genesis validators to genesis.json")
+      }
 
 			appState, err := json.MarshalIndent(appGenState, "", " ")
 			if err != nil {

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -114,7 +114,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			}
 
 			nodeID, valPublicKey, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
-      fmt.Print(nodeID)
+			fmt.Print(nodeID)
 			if err != nil {
 				return err
 			}

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -113,7 +113,8 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				initHeight = 1
 			}
 
-			nodeID, _, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
+			nodeID, valPublicKey, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
+      fmt.Print(nodeID)
 			if err != nil {
 				return err
 			}
@@ -135,6 +136,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				sdk.DefaultBondDenom = defaultDenom
 			}
 			appGenState := mbm.DefaultGenesis(cdc)
+			appGenState["stake"], err = SetGenesisValidator(valPublicKey)
 
 			appState, err := json.MarshalIndent(appGenState, "", " ")
 			if err != nil {

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -114,7 +114,6 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			}
 
 			nodeID, valPublicKey, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
-			fmt.Print(nodeID)
 			if err != nil {
 				return err
 			}

--- a/x/genutil/utils.go
+++ b/x/genutil/utils.go
@@ -27,6 +27,7 @@ func ExportGenesisFile(genesis *types.AppGenesis, genFile string) error {
 	if err := genesis.ValidateAndComplete(); err != nil {
 		return err
 	}
+	genesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = 1
 
 	return genesis.SaveAs(genFile)
 }

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -113,6 +113,9 @@ func setupGovKeeper(t *testing.T) (
 	stakingKeeper.EXPECT().BondDenom(ctx).Return("pol", nil).AnyTimes()
 	stakingKeeper.EXPECT().TokensFromConsensusPower(gomock.Any(), gomock.Any()).AnyTimes()
 	stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewHexCodec()).AnyTimes()
+	stakingKeeper.EXPECT().AddValidator(gomock.Any(), gomock.Any()).Return(nil)
+	stakingKeeper.EXPECT().IterateCurrentValidatorsAndApplyFn(gomock.Any(), gomock.Any()).Return(nil)
+
 	distributionKeeper.EXPECT().FundCommunityPool(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	// Gov keeper initializations

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -1,0 +1,88 @@
+package keeper_test
+
+import (
+	// "context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	// "github.com/0xPolygon/heimdall-v2/helper"
+	// chainmanagerKeeper "github.com/0xPolygon/heimdall-v2/x/chainmanager/keeper"
+	stakeTypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
+
+	// "github.com/cosmos/cosmos-sdk/codec"
+	// "github.com/cosmos/cosmos-sdk/codec/address"
+	// "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	// bankKeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	// "github.com/cosmos/cosmos-sdk/x/gov/testutil"
+)
+
+// setupTestKeeper initializes the StakeKeeper and sets up CurrentValidators
+// func setupTestKeeper(bankKeeper testutil.MockBankKeeper, ctx context.Context) (*stakeKeeper.Keeper, context.Context) {
+
+// 	// Create a new StakeKeeper instance with required dependencies
+// 	sk := stakeKeeper.NewKeeper(
+// 		codec.NewProtoCodec(types.NewInterfaceRegistry()),
+// 		nil, // Store key (mocked)
+// 		bankKeeper,
+// 		chainmanagerKeeper.Keeper{},
+// 		address.HexCodec{},       // Address Codec
+// 		&helper.ContractCaller{}, // Contract Caller (mocked)
+// 	)
+
+// 	// Initialize mock validators
+// 	mockValidators := []*stakeType.Validator{
+// 		{
+// 			EndEpoch:         0,
+// 			ValId:            1,
+// 			StartEpoch:       0,
+// 			Nonce:            0,
+// 			VotingPower:      1000,
+// 			PubKey:           []byte("Hello"),
+// 			Signer:           "0xworld",
+// 			LastUpdated:      "",
+// 			Jailed:           false,
+// 			ProposerPriority: 0,
+// 		},
+// 	}
+
+// 	sk.AddValidator(ctx, mockValidators)
+
+// 	return &sk, ctx
+// }
+
+func TestTally(t *testing.T) {
+	govKeeper, _, _, sk, _, _, ctx := setupGovKeeper(t)
+
+	// Create a minimal proposal
+	tp := TestProposal
+	accAddr, err := sdk.AccAddressFromHex("0xb316fa9fa91700d7084d377bfdc81eb9f232f5ff")
+	proposal, err := govKeeper.SubmitProposal(ctx, tp, "", "title", "description", accAddr, false)
+	mockValidators := []*stakeTypes.Validator{
+		{
+			EndEpoch:         0,
+			ValId:            1,
+			StartEpoch:       0,
+			Nonce:            0,
+			VotingPower:      1000,
+			PubKey:           []byte("Hello"),
+			Signer:           "0xworld",
+			LastUpdated:      "",
+			Jailed:           false,
+			ProposerPriority: 0,
+		},
+	}
+
+	sk.AddValidator(ctx, *mockValidators[0])
+
+	// Call Tally function
+	passes, burnDeposits, tallyResults, err := govKeeper.Tally(ctx, proposal)
+
+	// Assertions
+	require.NoError(t, err)
+	require.NotNil(t, tallyResults)
+
+	// Print results for debugging
+	t.Logf("Passes: %v, BurnDeposits: %v, Tally Results: %+v", passes, burnDeposits, tallyResults)
+}

--- a/x/gov/testutil/expected_keepers_mocks.go
+++ b/x/gov/testutil/expected_keepers_mocks.go
@@ -1050,6 +1050,20 @@ func (m *MockStakingKeeper) EXPECT() *MockStakingKeeperMockRecorder {
 	return m.recorder
 }
 
+// AddValidator mocks base method.
+func (m *MockStakingKeeper) AddValidator(ctx context.Context, validator types.Validator) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddValidator", ctx, validator)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddValidator indicates an expected call of AddValidator.
+func (mr *MockStakingKeeperMockRecorder) AddValidator(ctx, validator interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddValidator", reflect.TypeOf((*MockStakingKeeper)(nil).AddValidator), ctx, validator)
+}
+
 // BondDenom mocks base method.
 func (m *MockStakingKeeper) BondDenom(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/x/gov/types/expected_keepers.go
+++ b/x/gov/types/expected_keepers.go
@@ -33,6 +33,7 @@ type StakingKeeper interface {
 	*/
 
 	// HV2: added for heimdall business logic
+	AddValidator(ctx context.Context, validator stakeTypes.Validator) error
 	IterateCurrentValidatorsAndApplyFn(context.Context, func(stakeTypes.Validator) bool) error
 	GetValIdFromAddress(ctx context.Context, address string) (uint64, error)
 }


### PR DESCRIPTION
# Description

The init command now populates the Genesis validator. Previously, this process was done manually by adding validators to genesis.json.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to heimdall-v2 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
