### PR TITLE
fix init to be able to start heimdalld locally

### DIFF
--- a/x/genutil/client/cli/genaccount_test.go
+++ b/x/genutil/client/cli/genaccount_test.go
@@ -243,7 +243,7 @@ func TestBulkAddGenesisAccountCmd(t *testing.T) {
 			}
 			require.Equal(t, tc.expectErr, doesErr)
 
-			// an error already occurred, no need to check the state
+			// An error already occurred, no need to check the state.
 			if doesErr {
 				return
 			}
@@ -262,8 +262,8 @@ func TestBulkAddGenesisAccountCmd(t *testing.T) {
 				tempExpected[acc] = coins
 			}
 
-			// Find the bootstrap/validator account deterministically
-			// This account is injected at init, ad it has its own PubKey and address
+			// Find the bootstrap/validator account deterministically.
+			// This account is injected at init, and it has its own PubKey and address.
 			var bootstrapAddr string
 			for _, a := range genAccs {
 				if a.GetPubKey() != nil {

--- a/x/genutil/client/cli/genaccount_test.go
+++ b/x/genutil/client/cli/genaccount_test.go
@@ -262,7 +262,17 @@ func TestBulkAddGenesisAccountCmd(t *testing.T) {
 				tempExpected[acc] = coins
 			}
 
-			tempExpected[genAccs[0].GetAddress().String()] = sdk.NewCoins(sdk.NewInt64Coin("pol", 100000000000)) // ensure the first account is always present
+			// Find the bootstrap/validator account deterministically
+			// This account is injected at init, ad it has its own PubKey and address
+			var bootstrapAddr string
+			for _, a := range genAccs {
+				if a.GetPubKey() != nil {
+					bootstrapAddr = a.GetAddress().String()
+					break
+				}
+			}
+			require.NotEmpty(t, bootstrapAddr, "could not find bootstrap account with pubkey in auth genesis")
+			tempExpected[bootstrapAddr] = sdk.NewCoins(sdk.NewInt64Coin("pol", 100000000000))
 			require.EqualValues(t, len(tempExpected), len(bankState.Balances))
 			for _, acc := range bankState.Balances {
 				require.True(t, tempExpected[acc.Address].Equal(acc.Coins), "expected: %v, got: %v", tempExpected[acc.Address], acc.Coins)

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -10,8 +10,6 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math/unsafe"
-	milestonestypes "github.com/0xPolygon/heimdall-v2/x/milestone/types"
-	staketypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
 	cfg "github.com/cometbft/cometbft/config"
 	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -21,13 +19,15 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/go-bip39"
 	"github.com/spf13/cobra"
 
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	milestonestypes "github.com/0xPolygon/heimdall-v2/x/milestone/types"
+	staketypes "github.com/0xPolygon/heimdall-v2/x/stake/types"
 )
 
 const (
@@ -153,8 +153,9 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			var authGenState authtypes.GenesisState
 			var bankGenState banktypes.GenesisState
 
+			authGenState.Params = authtypes.DefaultGenesisState().Params
 			accs := []authtypes.GenesisAccount{}
-			baseAccount := authtypes.NewBaseAccount(accAddr, valPublicKey, 0, 0)
+			baseAccount := authtypes.NewBaseAccount(accAddr, valPublicKey, 1, 0)
 			accs = append(accs, baseAccount)
 			accs = authtypes.SanitizeGenesisAccounts(accs)
 			packed, err := authtypes.PackAccounts(accs)


### PR DESCRIPTION
# Description

fix `init` command to be able to start `heimdalld` locally. This was due to:
- using `account_number = 0` for the baseAccount, which is reserved to feeCollector
- using wrong `auth_params` and not the default ones

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy/mumbai
- [ ] I have created new e2e tests into express-cli