### PR TITLE
x/auth: auth fee nil guard

### DIFF
--- a/x/auth/tx/builder.go
+++ b/x/auth/tx/builder.go
@@ -180,15 +180,24 @@ func (w *wrapper) GetPubKeys() ([]cryptotypes.PubKey, error) {
 }
 
 func (w *wrapper) GetGas() uint64 {
+	if w.tx.AuthInfo.Fee == nil {
+		return 0
+	}
 	return w.tx.AuthInfo.Fee.GasLimit
 }
 
 func (w *wrapper) GetFee() sdk.Coins {
+	if w.tx.AuthInfo.Fee == nil {
+		return nil
+	}
 	return w.tx.AuthInfo.Fee.Amount
 }
 
 func (w *wrapper) FeePayer() []byte {
-	feePayer := w.tx.AuthInfo.Fee.Payer
+	var feePayer string
+	if w.tx.AuthInfo.Fee != nil {
+		feePayer = w.tx.AuthInfo.Fee.Payer
+	}
 	if feePayer != "" {
 		feePayerAddr, err := w.cdc.InterfaceRegistry().SigningContext().AddressCodec().StringToBytes(feePayer)
 		if err != nil {

--- a/x/auth/tx/builder.go
+++ b/x/auth/tx/builder.go
@@ -194,10 +194,12 @@ func (w *wrapper) GetFee() sdk.Coins {
 }
 
 func (w *wrapper) FeePayer() []byte {
-	var feePayer string
-	if w.tx.AuthInfo.Fee != nil {
-		feePayer = w.tx.AuthInfo.Fee.Payer
+	// A fee-less decoded tx has no payer; short-circuit before the GetSigners
+	// fallback, which dereferences AuthInfo.Fee.Payer without a nil guard.
+	if w.tx.AuthInfo.Fee == nil {
+		return nil
 	}
+	feePayer := w.tx.AuthInfo.Fee.Payer
 	if feePayer != "" {
 		feePayerAddr, err := w.cdc.InterfaceRegistry().SigningContext().AddressCodec().StringToBytes(feePayer)
 		if err != nil {
@@ -216,6 +218,9 @@ func (w *wrapper) FeePayer() []byte {
 }
 
 func (w *wrapper) FeeGranter() []byte {
+	if w.tx.AuthInfo.Fee == nil {
+		return nil
+	}
 	return w.tx.FeeGranter(w.cdc)
 }
 

--- a/x/auth/tx/nilfee_repro_test.go
+++ b/x/auth/tx/nilfee_repro_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 // decodeAuthInfo builds and decodes a tx with the given AuthInfo, leaving the
-// body minimal. It mirrors what a peer-gossiped tx looks like on the wire.
-func decodeAuthInfo(t *testing.T, authInfo *tx.AuthInfo) sdk.Tx {
+// body minimal, and returns it as an sdk.FeeTx. It mirrors what a decoded
+// wire tx looks like when the fee field is present or omitted.
+func decodeAuthInfo(t *testing.T, authInfo *tx.AuthInfo) sdk.FeeTx {
 	t.Helper()
 	cdc := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
 
@@ -25,31 +26,34 @@ func decodeAuthInfo(t *testing.T, authInfo *tx.AuthInfo) sdk.Tx {
 
 	decoded, err := DefaultTxDecoder(cdc)(txBz)
 	require.NoError(t, err)
-	return decoded
+	feeTx, ok := decoded.(sdk.FeeTx)
+	require.True(t, ok)
+	return feeTx
 }
 
 // A tx whose AuthInfo omits the Fee field (proto field 2) decodes with
-// AuthInfo.Fee == nil. The first ante decorator (SetUpContextDecorator) calls
-// GetGas() — this must not panic.
+// AuthInfo.Fee == nil. The fee accessors — reached first by the ante chain's
+// SetUpContextDecorator — must return zero values instead of dereferencing nil.
 func TestNilFeeAccessorsDoNotPanic(t *testing.T) {
-	feeTx, ok := decodeAuthInfo(t, &tx.AuthInfo{}).(sdk.FeeTx)
-	require.True(t, ok)
+	feeTx := decodeAuthInfo(t, &tx.AuthInfo{})
 
 	require.NotPanics(t, func() {
 		require.Equal(t, uint64(0), feeTx.GetGas())
 		require.Nil(t, feeTx.GetFee())
+		require.Nil(t, feeTx.FeePayer())
+		require.Nil(t, feeTx.FeeGranter())
 	})
 }
 
 // An empty (but present) Fee — what newBuilder always sets — must keep working.
 func TestEmptyFeeStillWorks(t *testing.T) {
-	feeTx := decodeAuthInfo(t, &tx.AuthInfo{Fee: &tx.Fee{}}).(sdk.FeeTx)
+	feeTx := decodeAuthInfo(t, &tx.AuthInfo{Fee: &tx.Fee{}})
 	require.Equal(t, uint64(0), feeTx.GetGas())
 	require.Nil(t, feeTx.GetFee())
 }
 
 // A populated Fee returns its values unchanged.
 func TestPopulatedFeeUnchanged(t *testing.T) {
-	feeTx := decodeAuthInfo(t, &tx.AuthInfo{Fee: &tx.Fee{GasLimit: 21000}}).(sdk.FeeTx)
+	feeTx := decodeAuthInfo(t, &tx.AuthInfo{Fee: &tx.Fee{GasLimit: 21000}})
 	require.Equal(t, uint64(21000), feeTx.GetGas())
 }

--- a/x/auth/tx/nilfee_repro_test.go
+++ b/x/auth/tx/nilfee_repro_test.go
@@ -1,0 +1,55 @@
+package tx
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeAuthInfo builds and decodes a tx with the given AuthInfo, leaving the
+// body minimal. It mirrors what a peer-gossiped tx looks like on the wire.
+func decodeAuthInfo(t *testing.T, authInfo *tx.AuthInfo) sdk.Tx {
+	t.Helper()
+	cdc := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+
+	bodyBz, err := (&tx.TxBody{Memo: "foo"}).Marshal()
+	require.NoError(t, err)
+	authInfoBz, err := authInfo.Marshal()
+	require.NoError(t, err)
+	txBz, err := (&tx.TxRaw{BodyBytes: bodyBz, AuthInfoBytes: authInfoBz}).Marshal()
+	require.NoError(t, err)
+
+	decoded, err := DefaultTxDecoder(cdc)(txBz)
+	require.NoError(t, err)
+	return decoded
+}
+
+// A tx whose AuthInfo omits the Fee field (proto field 2) decodes with
+// AuthInfo.Fee == nil. The first ante decorator (SetUpContextDecorator) calls
+// GetGas() — this must not panic.
+func TestNilFeeAccessorsDoNotPanic(t *testing.T) {
+	feeTx, ok := decodeAuthInfo(t, &tx.AuthInfo{}).(sdk.FeeTx)
+	require.True(t, ok)
+
+	require.NotPanics(t, func() {
+		require.Equal(t, uint64(0), feeTx.GetGas())
+		require.Nil(t, feeTx.GetFee())
+	})
+}
+
+// An empty (but present) Fee — what newBuilder always sets — must keep working.
+func TestEmptyFeeStillWorks(t *testing.T) {
+	feeTx := decodeAuthInfo(t, &tx.AuthInfo{Fee: &tx.Fee{}}).(sdk.FeeTx)
+	require.Equal(t, uint64(0), feeTx.GetGas())
+	require.Nil(t, feeTx.GetFee())
+}
+
+// A populated Fee returns its values unchanged.
+func TestPopulatedFeeUnchanged(t *testing.T) {
+	feeTx := decodeAuthInfo(t, &tx.AuthInfo{Fee: &tx.Fee{GasLimit: 21000}}).(sdk.FeeTx)
+	require.Equal(t, uint64(21000), feeTx.GetGas())
+}


### PR DESCRIPTION
## Summary

The `wrapper` accessors `GetGas`, `GetFee`, and `FeePayer` dereference `w.tx.AuthInfo.Fee` without a nil check. A protobuf-decoded tx can legitimately have `AuthInfo.Fee == nil` — the `fee` field (AuthInfo field 2) is optional and `DefaultTxDecoder` does not require it. When such a tx reaches the ante chain, the first decorator (`SetUpContextDecorator`) calls `GetGas()`, which then hits a nil pointer dereference.

`runTx`'s recovery middleware catches it, so it is not fatal — but every fee-less tx becomes a recovered panic (with a full stack capture) instead of a clean rejection. On a node that receives such txs over the mempool this is noisy and wasteful.

This guards the three accessors against a nil `Fee`, mirroring the guard the wrapper's setters (`SetGasLimit`, `SetFeeAmount`, `SetFeePayer`, `SetFeeGranter`) already apply. A fee-less tx now reports gas `0` / no fee and is rejected through the normal ante path (out-of-gas / fee checks) rather than panicking. A well-formed tx (Fee present) is completely unaffected.

## Executed tests

- `x/auth/tx/nilfee_repro_test.go`: decodes a tx whose `AuthInfo` omits the fee field and asserts `GetGas`/`GetFee` no longer panic and return zero values; plus round-trips confirming an empty `&Fee{}` and a populated `Fee` are unchanged.
- `go test ./x/auth/tx/... ./x/auth/ante/...` — pass.
- diffguard on `x/auth/tx/builder.go`: 100% mutation kill on the changed accessors, all gates green.

## Rollout notes

- Behavioral only — no proto, state, or API change. Backward-compatible.
- Not consensus-affecting; no hardfork required.
- Consumed by heimdall-v2 via a `go.mod` replace bump once this merges and the fork is tagged.