### PR TITLE
x/auth: add ante decorator capping fee coins per tx

### DIFF
--- a/x/auth/ante/fee_coins_cap.go
+++ b/x/auth/ante/fee_coins_cap.go
@@ -1,0 +1,48 @@
+package ante
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// FeeCoinsCapDecorator bounds the number of coins a tx may declare in its
+// fee. activeFn gates enforcement by block height; nil means always-on.
+type FeeCoinsCapDecorator struct {
+	maxFeeCoins int
+	activeFn    func(int64) bool
+}
+
+func NewFeeCoinsCapDecorator(maxFeeCoins int, activeFn func(int64) bool) FeeCoinsCapDecorator {
+	return FeeCoinsCapDecorator{maxFeeCoins: maxFeeCoins, activeFn: activeFn}
+}
+
+func (d FeeCoinsCapDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	// ReCheckTx never decides block inclusion, so skipping here is safe -
+	// the real check runs again when the tx is actually included.
+	if ctx.IsReCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
+	if d.activeFn != nil && !d.activeFn(ctx.BlockHeight()) {
+		return next(ctx, tx, simulate)
+	}
+
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+
+	fee := feeTx.GetFee()
+	if len(fee) > d.maxFeeCoins {
+		return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee,
+			"tx declares %d fee coins, max allowed is %d", len(fee), d.maxFeeCoins)
+	}
+
+	// Bound the count before validating - Validate is an O(n) scan.
+	if err := fee.Validate(); err != nil {
+		return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "invalid fee: %s", err)
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/x/auth/ante/fee_coins_cap_test.go
+++ b/x/auth/ante/fee_coins_cap_test.go
@@ -1,0 +1,165 @@
+package ante_test
+
+import (
+	"fmt"
+	"testing"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// feeCapTestTx is a minimal sdk.FeeTx exposing only what FeeCoinsCapDecorator reads.
+// Keep separate from capTestTx: it must NOT implement sdk.FeeTx, since
+// TestFeeCoinsCapDecoratorWrongTxType relies on that type-assertion failing.
+type feeCapTestTx struct {
+	fee sdk.Coins
+}
+
+func (t *feeCapTestTx) GetMsgs() []sdk.Msg                  { return nil }
+func (t *feeCapTestTx) GetMsgsV2() ([]proto.Message, error) { return nil, nil }
+func (t *feeCapTestTx) GetGas() uint64                      { return 0 }
+func (t *feeCapTestTx) GetFee() sdk.Coins                   { return t.fee }
+func (t *feeCapTestTx) FeePayer() []byte                    { return nil }
+func (t *feeCapTestTx) FeeGranter() []byte                  { return nil }
+
+// manyDistinctValidCoins builds n coins that each individually pass
+// Coins.Validate() (positive amount, valid denom, sorted, no duplicates),
+// unlike manyInvalidCoins - exercises the count cap independently of Validate.
+func manyDistinctValidCoins(n int) sdk.Coins {
+	coins := make(sdk.Coins, n)
+	for i := range coins {
+		coins[i] = sdk.Coin{Denom: fmt.Sprintf("aaa%06d", i), Amount: math.OneInt()}
+	}
+	return coins
+}
+
+func manyInvalidCoins(n int) sdk.Coins {
+	coins := make(sdk.Coins, n)
+	for i := range coins {
+		coins[i] = sdk.Coin{Denom: "", Amount: math.ZeroInt()}
+	}
+	return coins
+}
+
+func TestFeeCoinsCapDecorator(t *testing.T) {
+	const cap = 1
+
+	alwaysActive := func(int64) bool { return true }
+	alwaysInactive := func(int64) bool { return false }
+	activateAt100 := func(h int64) bool { return h >= 100 }
+
+	tests := []struct {
+		name       string
+		decorator  ante.FeeCoinsCapDecorator
+		height     int64
+		fee        sdk.Coins
+		recheckTx  bool
+		wantReject bool
+		wantErrIs  error
+	}{
+		{
+			name:      "empty fee accepts",
+			decorator: ante.NewFeeCoinsCapDecorator(cap, alwaysActive),
+			fee:       sdk.Coins{},
+		},
+		{
+			name:      "single valid coin accepts",
+			decorator: ante.NewFeeCoinsCapDecorator(cap, alwaysActive),
+			fee:       sdk.NewCoins(sdk.NewInt64Coin("pol", 1)),
+		},
+		{
+			name:       "two coins rejects (over cap)",
+			decorator:  ante.NewFeeCoinsCapDecorator(cap, alwaysActive),
+			fee:        sdk.NewCoins(sdk.NewInt64Coin("aaa", 1), sdk.NewInt64Coin("bbb", 1)),
+			wantReject: true,
+			wantErrIs:  sdkerrors.ErrInsufficientFee,
+		},
+		{
+			name:       "many malformed coins (zero amount, empty denom) rejects",
+			decorator:  ante.NewFeeCoinsCapDecorator(cap, alwaysActive),
+			fee:        manyInvalidCoins(100000),
+			wantReject: true,
+			wantErrIs:  sdkerrors.ErrInsufficientFee,
+		},
+		{
+			name:       "many individually-valid distinct-denom coins still rejects",
+			decorator:  ante.NewFeeCoinsCapDecorator(cap, alwaysActive),
+			fee:        manyDistinctValidCoins(10000),
+			wantReject: true,
+			wantErrIs:  sdkerrors.ErrInsufficientFee,
+		},
+		{
+			name:       "single coin with zero amount rejects (caught by Validate, not count)",
+			decorator:  ante.NewFeeCoinsCapDecorator(cap, alwaysActive),
+			fee:        sdk.Coins{sdk.Coin{Denom: "pol", Amount: math.ZeroInt()}},
+			wantReject: true,
+			wantErrIs:  sdkerrors.ErrInsufficientFee,
+		},
+		{
+			name:       "single coin with empty denom rejects",
+			decorator:  ante.NewFeeCoinsCapDecorator(cap, alwaysActive),
+			fee:        sdk.Coins{sdk.Coin{Denom: "", Amount: math.OneInt()}},
+			wantReject: true,
+			wantErrIs:  sdkerrors.ErrInsufficientFee,
+		},
+		{
+			name:      "inactive (activeFn=false) skips enforcement even over cap",
+			decorator: ante.NewFeeCoinsCapDecorator(cap, alwaysInactive),
+			fee:       manyInvalidCoins(1000),
+		},
+		{
+			name:       "activeFn nil acts as always-on, rejects over cap",
+			decorator:  ante.NewFeeCoinsCapDecorator(cap, nil),
+			fee:        manyInvalidCoins(1000),
+			wantReject: true,
+		},
+		{
+			name:      "below activation height: over cap accepts",
+			decorator: ante.NewFeeCoinsCapDecorator(cap, activateAt100),
+			height:    99,
+			fee:       manyInvalidCoins(1000),
+		},
+		{
+			name:       "at activation height: over cap rejects",
+			decorator:  ante.NewFeeCoinsCapDecorator(cap, activateAt100),
+			height:     100,
+			fee:        manyInvalidCoins(1000),
+			wantReject: true,
+		},
+		{
+			name:      "ReCheckTx skips enforcement even over cap and past activation",
+			decorator: ante.NewFeeCoinsCapDecorator(cap, activateAt100),
+			height:    100,
+			fee:       manyInvalidCoins(1000),
+			recheckTx: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := sdk.Context{}.WithBlockHeight(tt.height).WithIsReCheckTx(tt.recheckTx)
+			tx := &feeCapTestTx{fee: tt.fee}
+			_, err := tt.decorator.AnteHandle(ctx, tx, false, terminalHandler)
+			if tt.wantReject {
+				require.Error(t, err)
+				if tt.wantErrIs != nil {
+					require.ErrorIs(t, err, tt.wantErrIs)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFeeCoinsCapDecoratorWrongTxType(t *testing.T) {
+	decorator := ante.NewFeeCoinsCapDecorator(1, nil)
+	ctx := sdk.Context{}
+	_, err := decorator.AnteHandle(ctx, &capTestTx{}, false, terminalHandler)
+	require.Error(t, err)
+	require.ErrorIs(t, err, sdkerrors.ErrTxDecode)
+}


### PR DESCRIPTION
## Summary

Adds `FeeCoinsCapDecorator`, a new ante decorator in `x/auth/ante` that bounds the number of coins a transaction may declare in its fee. Enforcement is gated by an `activeFn func(int64) bool` height predicate (nil = always on), and skipped on `ReCheckTx` since it never decides block inclusion. Both `maxFeeCoins` and `activeFn` are chosen by the consuming application when assembling its ante chain - this PR adds the decorator only and does not wire it into any default ante handler, matching the pattern used for `MsgMultiSendCapDecorator` (#90).

## Executed tests

- New table-driven unit tests (`x/auth/ante/fee_coins_cap_test.go`, 12 cases) covering: empty/single/over-cap fee counts; many malformed vs many individually-valid distinct-denom coins; zero-amount and empty-denom rejection via `Coins.Validate()`; nil, always-true, always-false, and height-gated `activeFn`; activation height boundary (H-1 / H); `ReCheckTx` skip; wrong tx type.
- `go build ./x/auth/ante/...` and `go test ./x/auth/ante/...` pass locally.

## Rollout notes

- No behavior change from this PR alone - the decorator is inert until an application adds it to its ante chain.
- Once wired, it changes transaction acceptance, so consuming chains (Heimdall-v2) must activate it via a height-gated `activeFn` as part of a coordinated upgrade; pre-activation behavior is unchanged.
- No state migrations, no API/store changes. Additive file in `x/auth/ante`, no modifications to existing decorators.